### PR TITLE
align with updated aws neptune lambda docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,31 @@
 
 ## Overview
 A very simple Gremlin client to robustly query AWS Neptune from AWS Lambda. The client will automatically
-reestablish a connection to the database if the web socket connection closes and will also automatically 
-retry (5 times) when it encounters `ConcurrentModificationException` and `ReadOnlyViolationException` errors.
+reestablish a connection to the database if the web socket connection closes and will also automatically
+retry (up to 5 times, with exponential backoff and jitter) when it encounters `ConcurrentModificationException`
+and `ReadOnlyViolationException` errors.
 
 ## Usage
 
-This client is instantiated with a factory function and exposes a single function called `query`. `query` accepts 
-a single argument, which is a function that use the Gremlin `g` object.
+This client is instantiated with a factory function and exposes a `query` function that accepts a single
+argument: a function that uses the Gremlin `g` object. It also exposes a `close` function for graceful shutdown.
 
 ```js
 const gremlinClient = require('neptune-lambda-client');
 
-const {query} = gremlinClient.create({
-    host: 'neptune-db-url',
-    port: '8182',
-    useIam: true
-});
+const {query} = gremlinClient.create('neptune-db-url', '8182', { useIam: true });
 
 async function getNode(id) {
     return query(async g => g.V(id).next().then(x => x.value));
 }
 ```
+
+## Known limitations
+
+Per the [AWS Neptune Lambda guidance](https://docs.aws.amazon.com/neptune/latest/userguide/lambda-functions-examples.html#lambda-functions-examples-javascript),
+if the underlying WebSocket is closed after the driver sends a request but before the response arrives,
+the query resolves with `undefined` rather than throwing. Because this state cannot be turned into an
+exception on the request/response path, we instead throw from the socket's `close` handler when the close
+code is `1006` (abnormal closure) — this surfaces as an unhandled exception that fails the Lambda
+invocation, so the client invoking the Lambda can retry. We recommend implementing retry logic on the
+caller side as well as using the built-in retry in this library.

--- a/index.js
+++ b/index.js
@@ -48,7 +48,9 @@ module.exports = {
             const c = new DriverRemoteConnection(
                 url,
                 {
-                    mimeType: 'application/vnd.gremlin-v2.0+json',
+                    // Lambda freezes between invocations; heartbeats fired just before freeze
+                    // time out after thaw, causing noisy disconnects. Our reconnect-on-error path
+                    // handles dead connections, so skip the liveness pings.
                     pingEnabled: false,
                     headers: useIam ? createHeaders(host, port, path, {}) : {}
                 });
@@ -102,8 +104,11 @@ module.exports = {
                         return bail(err);
                     })
                 }, {
-                    factor: 1,
-                    retries: 5
+                    retries: 5,
+                    factor: 2,
+                    minTimeout: 1000,
+                    maxTimeout: 10000,
+                    randomize: true
                 });
             },
             close: async () => {


### PR DESCRIPTION
## Summary
- Drop `mimeType: 'application/vnd.gremlin-v2.0+json'` from the driver options — it's no longer needed and the AWS example doesn't set it
- Switch the retry backoff from fixed 1s (`factor: 1`) to exponential with jitter (`factor: 2`, `minTimeout: 1000`, `maxTimeout: 10000`, `randomize: true`), matching the AWS docs guidance: _"In a production application consider use of exponential backoff with jitter rather than a fixed interval"_
- Keep `pingEnabled: false` (the AWS example uses the gremlin default of `true`, but Lambda's freeze/thaw cycle makes heartbeats fire noisy timeouts — the existing reconnect path handles dead connections fine). Added a code comment explaining the deviation.
- Fix the README usage example, which showed `create({host, port, useIam})` but the actual signature is `create(host, port, {useIam})`
- Add a **Known limitations** section to the README covering the AWS-documented null-on-close edge case and what our `close` handler's 1006 throw is actually doing

## Test plan
- [x] `npm test` passes locally (9/9)
- [ ] CI passes on Node 22 and 24