### PR TITLE
feat!: move gremlin to peerDependencies (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ reestablish a connection to the database if the web socket connection closes and
 retry (up to 5 times, with exponential backoff and jitter) when it encounters `ConcurrentModificationException`
 and `ReadOnlyViolationException` errors.
 
+## Installation
+
+`gremlin` is a peer dependency — install it alongside the client so your application controls the
+exact version that talks to your Neptune cluster:
+
+```sh
+npm install neptune-lambda-client gremlin
+```
+
 ## Usage
 
 This client is instantiated with a factory function and exposes a `query` function that accepts a single

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,25 @@
 {
   "name": "neptune-lambda-client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neptune-lambda-client",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "async-retry": "1.3.3",
-        "aws4": "1.11.0",
-        "gremlin": "3.5.2"
+        "aws4": "1.11.0"
       },
       "devDependencies": {
+        "gremlin": "3.5.2",
         "testcontainers": "^12.0.0",
         "vitest": "^2.1.9",
         "ws": "^8.18.0"
+      },
+      "peerDependencies": {
+        "gremlin": "^3.5.0"
       }
     },
     "node_modules/@balena/dockerignore": {
@@ -1286,6 +1289,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-lock": {
@@ -2181,6 +2185,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/gremlin/-/gremlin-3.5.2.tgz",
       "integrity": "sha512-GPFevKxQZwOSweuMDDyy1+bwQ7bDc1+41DRYeoYJOgkbiR5fbQslFCjOuWvsVF+FEQr/De4pG8ZqVP6wJMrYMQ==",
+      "dev": true,
       "dependencies": {
         "ws": "^6.2.2"
       },
@@ -2192,6 +2197,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
       "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -4315,7 +4321,8 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "async-lock": {
       "version": "1.4.1",
@@ -4924,6 +4931,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/gremlin/-/gremlin-3.5.2.tgz",
       "integrity": "sha512-GPFevKxQZwOSweuMDDyy1+bwQ7bDc1+41DRYeoYJOgkbiR5fbQslFCjOuWvsVF+FEQr/De4pG8ZqVP6wJMrYMQ==",
+      "dev": true,
       "requires": {
         "ws": "^6.2.2"
       },
@@ -4932,6 +4940,7 @@
           "version": "6.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
           "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+          "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neptune-lambda-client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Gremlin client to robustly query AWS Neptune from AWS Lambda",
   "type": "module",
   "exports": {
@@ -29,10 +29,13 @@
   "homepage": "https://github.com/svozza/neptune-lambda-client#readme",
   "dependencies": {
     "async-retry": "1.3.3",
-    "aws4": "1.11.0",
-    "gremlin": "3.5.2"
+    "aws4": "1.11.0"
+  },
+  "peerDependencies": {
+    "gremlin": "^3.5.0"
   },
   "devDependencies": {
+    "gremlin": "3.5.2",
     "testcontainers": "^12.0.0",
     "vitest": "^2.1.9",
     "ws": "^8.18.0"


### PR DESCRIPTION
## Summary

- Move `gremlin` from `dependencies` to `peerDependencies` (`^3.5.0`); keep it in `devDependencies` pinned to the current `3.5.2` so tests resolve.
- Bump package version to `3.0.0`.
- README "Installation" section added: `npm install neptune-lambda-client gremlin`.

Closes #7.

## Why

`gremlin` leaks across the API surface — anything a consumer does with it directly (e.g. `gremlin.process.statics.V()` inside a `.to()` clause, `instanceof Vertex` on results) silently breaks if two copies resolve in `node_modules`. A peer dep forces a single resolved copy and lets the consumer pin the version that matches their Neptune cluster.

## Breaking change

Consumers must now install `gremlin` themselves. Released as **v3.0.0**.

## Test plan

- [x] `TESTCONTAINERS_RYUK_DISABLED=true npm test` — 15/15 pass
- [x] `npm ls gremlin` shows a single `gremlin@3.5.2` resolution
- [x] CI green