### PR TITLE
chore: slim published tarball via files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

Adds a `files` field to `package.json` so the published tarball only contains `index.js` (plus the auto-included `LICENSE`, `README.md`, `package.json`).

Closes #9.

## Before / after

| | files | size | unpacked |
|--|--|--|--|
| Before | 10 | 6.9 kB | 21.8 kB |
| After  | 4  | 3.8 kB | 8.9 kB |

`test/**` and the `gremlin-server.js` helper no longer ship to consumers.

## Test plan

- [x] `npm pack --dry-run` shows 4 files
- [x] CI green